### PR TITLE
This PR makes the navbar logo and "Mongo Buddy" brand text clickable, allowing users to return to the home page when clicked.

### DIFF
--- a/src/Components/Index page/Navbar.jsx
+++ b/src/Components/Index page/Navbar.jsx
@@ -1,6 +1,6 @@
 import BearMascot from '../BearMascot';
 
-function Navbar({ user, onLogout, onGetStarted, onGoHome, onGoToModules }){  
+function Navbar({ user, onLogout, onGetStarted, onBackToHome, onGoToModules }){
     return(
   <nav className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -8,7 +8,7 @@ function Navbar({ user, onLogout, onGetStarted, onGoHome, onGoToModules }){
             <div className="flex items-center">
               <div className="flex-shrink-0">
                 <button 
-                  onClick={onGoHome}
+                  onClick={onBackToHome}
                   className="flex items-center space-x-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded-lg p-1"
                   aria-label="Go to home page"
                 >
@@ -21,7 +21,7 @@ function Navbar({ user, onLogout, onGetStarted, onGoHome, onGoToModules }){
             </div>
             <div className="hidden md:flex items-center space-x-8">
               <button 
-                onClick={onGoHome}
+                onClick={onBackToHome}
                 className="text-gray-700 hover:text-green-600 px-3 py-2 rounded-md text-sm font-medium cursor-pointer"
               >
                 Home

--- a/src/Components/Index page/Navbar.jsx
+++ b/src/Components/Index page/Navbar.jsx
@@ -9,7 +9,7 @@ function Navbar({ user, onLogout, onGetStarted, onBackToHome, onGoToModules }){
               <div className="flex-shrink-0">
                 <button 
                   onClick={onBackToHome}
-                  className="flex items-center space-x-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded-lg p-1"
+                  className="flex items-center space-x-2 hover:opacity-80 transition-opacity cursor-pointer"
                   aria-label="Go to home page"
                 >
                   <div className="w-8 h-8 bg-green-600 rounded-lg flex items-center justify-center">

--- a/src/Components/Index page/Navbar.jsx
+++ b/src/Components/Index page/Navbar.jsx
@@ -7,12 +7,16 @@ function Navbar({ user, onLogout, onGetStarted, onGoHome, onGoToModules }){
           <div className="flex justify-between h-16">
             <div className="flex items-center">
               <div className="flex-shrink-0">
-                <div className="flex items-center space-x-2">
+                <button 
+                  onClick={onGoHome}
+                  className="flex items-center space-x-2 hover:opacity-80 transition-opacity cursor-pointer focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 rounded-lg p-1"
+                  aria-label="Go to home page"
+                >
                   <div className="w-8 h-8 bg-green-600 rounded-lg flex items-center justify-center">
                     <BearMascot size="20px" />
                   </div>
                   <span className="text-xl font-bold text-gray-900">Mongo Buddy</span>
-                </div>
+                </button>
               </div>
             </div>
             <div className="hidden md:flex items-center space-x-8">


### PR DESCRIPTION
#1 -Issue 
##Changes Made
- Wrapped logo and brand text in a clickable button element
- Added `onClick` handler to redirect to home page
- Added hover effect (opacity transition) for visual feedback
- Added focus ring for keyboard accessibility
- Added aria-label for screen readers

<img width="707" height="171" alt="Screenshot 2025-10-02 155037" src="https://github.com/user-attachments/assets/16225b2d-5561-4df8-846e-145d5cbed002" />
