### PR TITLE
fix: update auth page theme to match home page branding

### DIFF
--- a/src/Components/Auth/AuthForm.jsx
+++ b/src/Components/Auth/AuthForm.jsx
@@ -149,11 +149,11 @@ const AuthForm = ({onAuthSuccess }) => {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-purple-50 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 via-white to-green-100 py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-md w-full space-y-8">
         <div>
-          <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-blue-100">
-            <User className="h-6 w-6 text-blue-600" />
+          <div className="mx-auto h-12 w-12 flex items-center justify-center rounded-full bg-green-100">
+            <User className="h-6 w-6 text-green-600" />
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
             {isLogin ? 'Sign in to your account' : 'Create your account'}
@@ -182,9 +182,9 @@ const AuthForm = ({onAuthSuccess }) => {
                     autoComplete="name"
                     value={formData.fullName}
                     onChange={handleInputChange}
-                    className={`appearance-none relative block w-full pl-10 pr-3 py-2 border ${
-                      errors.fullName ? 'border-red-300' : 'border-gray-300'
-                    } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm`}
+                  className={`appearance-none relative block w-full pl-10 pr-3 py-2 border ${
+                    errors.fullName ? 'border-red-300' : 'border-gray-300'
+                  } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-green-500 focus:border-green-500 focus:z-10 sm:text-sm`}
                     placeholder="Enter your full name"
                   />
                 </div>
@@ -212,7 +212,7 @@ const AuthForm = ({onAuthSuccess }) => {
                   onChange={handleInputChange}
                   className={`appearance-none relative block w-full pl-10 pr-3 py-2 border ${
                     errors.email ? 'border-red-300' : 'border-gray-300'
-                  } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm`}
+                  } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-green-500 focus:border-green-500 focus:z-10 sm:text-sm`}
                   placeholder="Enter your email"
                 />
               </div>
@@ -239,7 +239,7 @@ const AuthForm = ({onAuthSuccess }) => {
                   onChange={handleInputChange}
                   className={`appearance-none relative block w-full pl-10 pr-10 py-2 border ${
                     errors.password ? 'border-red-300' : 'border-gray-300'
-                  } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm`}
+                  } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-green-500 focus:border-green-500 focus:z-10 sm:text-sm`}
                   placeholder="Enter your password"
                 />
                 <div className="absolute inset-y-0 right-0 pr-3 flex items-center">
@@ -274,9 +274,9 @@ const AuthForm = ({onAuthSuccess }) => {
                     autoComplete="new-password"
                     value={formData.confirmPassword}
                     onChange={handleInputChange}
-                    className={`appearance-none relative block w-full pl-10 pr-3 py-2 border ${
-                      errors.confirmPassword ? 'border-red-300' : 'border-gray-300'
-                    } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm`}
+                  className={`appearance-none relative block w-full pl-10 pr-3 py-2 border ${
+                    errors.confirmPassword ? 'border-red-300' : 'border-gray-300'
+                  } placeholder-gray-500 text-gray-900 rounded-lg focus:outline-none focus:ring-green-500 focus:border-green-500 focus:z-10 sm:text-sm`}
                     placeholder="Confirm your password"
                   />
                 </div>
@@ -309,7 +309,7 @@ const AuthForm = ({onAuthSuccess }) => {
               className={`group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-lg text-white ${
                 isLoading
                   ? 'bg-gray-400 cursor-not-allowed'
-                  : 'bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+                  : 'bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500'
               } transition-colors`}
             >
               {isLoading ? (
@@ -337,7 +337,7 @@ const AuthForm = ({onAuthSuccess }) => {
                   fullName: ''
                 });
               }}
-              className="text-sm text-blue-600 hover:text-blue-500"
+              className="text-sm text-green-600 hover:text-green-500"
             >
               {isLogin 
                 ? "Don't have an account? Sign up" 


### PR DESCRIPTION
- Change background gradient from blue-purple to green (matching home page)
- Replace all blue accent colors with green (blue-600 -> green-600)
- Update user icon background from blue to green
- Change input focus states from blue to green
- Update submit button theme from blue to green
- Change toggle link colors from blue to green
- Ensures consistent brand identity across the entire platform

<img width="1919" height="907" alt="image" src="https://github.com/user-attachments/assets/78556f47-f3e2-464a-b34e-53751d9a51a5" />


Issue #13 

